### PR TITLE
tests: add more tests for workspaceModel.js

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -13,13 +13,26 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: "20.x"
       - name: Install dependencies
         run: npm ci
       - name: Check code formatting
         run: npm run check:format
       - name: Lint code
         run: npm run check:lint
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
   commit-message:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: "20.x"
       - name: Install commitlint
         run: |
           npm install @commitlint/config-conventional @commitlint/cli

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
                 logError: "readonly",
                 print: "readonly",
                 printerr: "readonly",
+                process: "readonly",
                 window: "readonly",
                 TextEncoder: "readonly",
                 TextDecoder: "readonly",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,83 @@
         "@eslint/js": "^9.18.0",
         "@girs/gjs": "^4.0.0-beta.19",
         "@girs/gnome-shell": "^47.0.0",
+        "@vitest/coverage-v8": "^2.1.8",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^9.1.0",
         "prettier": "^3.4.2",
         "vitest": "^2.1.8"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1393,12 +1465,97 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.30.1",
@@ -1680,6 +1837,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.8.tgz",
+      "integrity": "sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.8",
+        "vitest": "2.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
@@ -1831,6 +2021,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -2015,6 +2218,20 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2368,6 +2585,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2383,6 +2617,27 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2396,6 +2651,32 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2405,6 +2686,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2463,6 +2751,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2482,6 +2780,76 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2542,6 +2910,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -2550,6 +2925,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -2563,6 +2966,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2632,6 +3045,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2663,6 +3083,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -2793,6 +3230,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2823,6 +3273,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2846,6 +3309,110 @@
       "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2871,6 +3438,47 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {
@@ -3130,6 +3738,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@eslint/js": "^9.18.0",
     "@girs/gjs": "^4.0.0-beta.19",
     "@girs/gnome-shell": "^47.0.0",
+    "@vitest/coverage-v8": "^2.1.8",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.4.2",

--- a/src/shell/core/workspaceModel.js
+++ b/src/shell/core/workspaceModel.js
@@ -1521,4 +1521,14 @@ function insertWindowBetweenMrus(
     }
 }
 
-export { WorkspaceModel };
+let TestEnv;
+
+if (process.env.NODE_ENV === "test") {
+    TestEnv = {
+        Column,
+        Item,
+        WindowOpeningPosition,
+    };
+}
+
+export { TestEnv, WorkspaceModel };

--- a/src/shell/core/workspaceModel.js
+++ b/src/shell/core/workspaceModel.js
@@ -151,7 +151,9 @@ class Column {
      */
     constructor({ items = [], focusedItem = 0 } = {}) {
         Debug.assert(
-            Array.isArray(items) && items.length > 0,
+            Array.isArray(items) &&
+                items.every((item) => item instanceof Item) &&
+                items.length > 0,
             `Columns must have at least one item: ${items}`,
         );
 
@@ -196,7 +198,10 @@ class Column {
      *
      * @returns {Column}
      */
-    clone({ items = this.#items, focusedItem = this.#focusedItem } = {}) {
+    clone({
+        items = this.#items.map((i) => i.clone()),
+        focusedItem = this.#focusedItem,
+    } = {}) {
         return new Column({ items, focusedItem });
     }
 
@@ -348,7 +353,8 @@ class WorkspaceModel {
         },
     } = {}) {
         Debug.assert(
-            Array.isArray(columns),
+            Array.isArray(columns) &&
+                columns.every((col) => col instanceof Column),
             `columns must be an array of columns: ${columns}`,
         );
 
@@ -372,11 +378,12 @@ class WorkspaceModel {
 
     clone({
         focusedColumn = this.#focusedColumn,
-        columns = this.#columns,
+        columns = this.#columns.map((col) => col.clone()),
         workArea = this.#workArea,
+        workspaceModelManager = this.#workspaceModelManager,
     } = {}) {
         return new WorkspaceModel({
-            workspaceModelManager: this.#workspaceModelManager,
+            workspaceModelManager,
             columns,
             focusedColumn,
             workArea,
@@ -1393,17 +1400,16 @@ function insertWindowOnLeftOfFocus(
 ) {
     const windowFrame = window.get_frame_rect();
     const [prevFocusedWindow] = mrus;
+    const prevCol =
+        prevFocusedWindow &&
+        columns.find((col) => col.contains(prevFocusedWindow));
     const newColumn = new Column({
         focusedItem: 0,
         items: [
             new Item({
                 value: window,
                 rect: {
-                    x:
-                        prevFocusedWindow ?
-                            prevFocusedWindow.get_frame_rect().x -
-                            windowFrame.width
-                        :   0,
+                    x: prevCol ? prevCol.rect.x - windowFrame.width : 0,
                     y: Math.floor(
                         workspace.height / 2 - windowFrame.height / 2,
                     ),
@@ -1439,17 +1445,16 @@ function insertWindowOnRightOfFocus(
 ) {
     const windowFrame = window.get_frame_rect();
     const [prevFocusedWindow] = mrus;
+    const prevCol =
+        prevFocusedWindow &&
+        columns.find((col) => col.contains(prevFocusedWindow));
     const newColumn = new Column({
         focusedItem: 0,
         items: [
             new Item({
                 value: window,
                 rect: {
-                    x:
-                        prevFocusedWindow ?
-                            prevFocusedWindow.get_frame_rect().x +
-                            windowFrame.width
-                        :   0,
+                    x: prevCol ? prevCol.rect.x + windowFrame.width : 0,
                     y: Math.floor(
                         workspace.height / 2 - windowFrame.height / 2,
                     ),
@@ -1498,9 +1503,11 @@ function insertWindowBetweenMrus(
         );
     }
 
-    const direction =
-        prevFocusedWindow.get_frame_rect().x -
-        prevPrevFocusedWindow.get_frame_rect().x;
+    const prevCol = columns.find((col) => col.contains(prevFocusedWindow));
+    const prevPrevCol = columns.find((col) =>
+        col.contains(prevPrevFocusedWindow),
+    );
+    const direction = prevCol.rect.x - prevPrevCol.rect.x;
 
     if (direction > 0) {
         return insertWindowOnLeftOfFocus(

--- a/tests/shell/core/workspaceModel.test.js
+++ b/tests/shell/core/workspaceModel.test.js
@@ -1,25 +1,1000 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { WorkspaceModel } from "../../../src/shell/core/workspaceModel.js";
+import {
+    TestEnv,
+    WorkspaceModel,
+} from "../../../src/shell/core/workspaceModel.js";
+
+describe("Workspace Model", () => {
+    it("getGrid should return the item grid in global coordinates", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+        const grid = model.getGrid();
+
+        testGridItems(grid.items, [
+            [
+                // Column 0
+                new TestEnv.Item({
+                    value: windows[0],
+                    rect: {
+                        x: 350,
+                        y: 350,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+                new TestEnv.Item({
+                    value: windows[1],
+                    rect: {
+                        x: 400,
+                        y: 450,
+                        width: 50,
+                        height: 100,
+                    },
+                }),
+            ],
+            [
+                // Column 1 (Focused)
+                new TestEnv.Item({
+                    value: windows[2],
+                    rect: {
+                        x: 450,
+                        y: 450,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+            ],
+            [
+                // Column 2
+                new TestEnv.Item({
+                    value: windows[3],
+                    rect: {
+                        x: 550,
+                        y: 475,
+                        width: 50,
+                        height: 50,
+                    },
+                }),
+                new TestEnv.Item({
+                    value: windows[4],
+                    rect: {
+                        x: 550,
+                        y: 525,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+            ],
+            [
+                // Column 3
+                new TestEnv.Item({
+                    value: windows[5],
+                    rect: {
+                        x: 650,
+                        y: 450,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+            ],
+        ]);
+    });
+
+    it("relayout should reflow the layout around the (focused) input window", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+        const { model: newModel } = model.relayout(windows[0]);
+
+        testGridItems(newModel.getGrid().items, [
+            [
+                // Column 0 (Focused)
+                new TestEnv.Item({
+                    value: windows[0],
+                    rect: {
+                        x: 450,
+                        y: 450,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+                new TestEnv.Item({
+                    value: windows[1],
+                    rect: {
+                        x: 475,
+                        y: 550,
+                        width: 50,
+                        height: 100,
+                    },
+                }),
+            ],
+            [
+                // Column 1
+                new TestEnv.Item({
+                    value: windows[2],
+                    rect: {
+                        x: 550,
+                        y: 450,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+            ],
+            [
+                // Column 2
+                new TestEnv.Item({
+                    value: windows[3],
+                    rect: {
+                        x: 650,
+                        y: 475,
+                        width: 50,
+                        height: 50,
+                    },
+                }),
+                new TestEnv.Item({
+                    value: windows[4],
+                    rect: {
+                        x: 650,
+                        y: 525,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+            ],
+            [
+                // Column 3
+                new TestEnv.Item({
+                    value: windows[5],
+                    rect: {
+                        x: 750,
+                        y: 450,
+                        width: 100,
+                        height: 100,
+                    },
+                }),
+            ],
+        ]);
+    });
+
+    describe("getItemOnLeftOfFocus should get the window on the left of the current focus if there is one", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should return the window on the left of the current focus window", () => {
+            const win = model.getItemOnLeftOfFocus();
+
+            expect(win).toBe(windows[1]);
+        });
+
+        it("should return undefined if there is no window on the left", () => {
+            const { model: newModel } = model.relayout(windows[0]);
+
+            expect(newModel.getItemOnLeftOfFocus()).toBeUndefined();
+        });
+    });
+
+    describe("getItemOnRightOfFocus should get the window on the right of the current focus if there is one", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should return the window on the right of the current focus window", () => {
+            const win = model.getItemOnRightOfFocus();
+
+            expect(win).toBe(windows[3]);
+        });
+
+        it("should return undefined if there is no window on the right", () => {
+            const { model: newModel } = model.relayout(windows[5]);
+
+            expect(newModel.getItemOnRightOfFocus()).toBeUndefined();
+        });
+    });
+
+    describe("getItemAboveFocus should get the window above the current focus if there is one", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should return undefined if there is no window above", () => {
+            const win = model.getItemAboveFocus();
+
+            expect(win).toBeUndefined();
+        });
+
+        it("should return the window above the current focus window", () => {
+            const { model: newModel } = model.relayout(windows[1]);
+            const win = newModel.getItemAboveFocus();
+
+            expect(win).toBe(windows[0]);
+        });
+    });
+
+    describe("getItemBelowFocus should get the window below the current focus if there is one", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should return undefined if there is no window below", () => {
+            const win = model.getItemBelowFocus();
+
+            expect(win).toBeUndefined();
+        });
+
+        it("should return the window below the current focus window", () => {
+            const { model: newModel } = model.relayout(windows[0]);
+            const win = newModel.getItemBelowFocus();
+
+            expect(win).toBe(windows[1]);
+        });
+    });
+
+    describe("moveFocusedColumnLeft should move the focused column to the left if possible", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+        const { model: newModel } = model.moveFocusedColumnLeft();
+
+        it("should move the focused column to the left if possible", () => {
+            testGridItems(newModel.getGrid().items, [
+                [
+                    // Column 0 (Focused)
+                    new TestEnv.Item({
+                        value: windows[2],
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 1
+                    new TestEnv.Item({
+                        value: windows[0],
+                        rect: {
+                            x: 550,
+                            y: 350,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[1],
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 2
+                    new TestEnv.Item({
+                        value: windows[3],
+                        rect: {
+                            x: 650,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[4],
+                        rect: {
+                            x: 650,
+                            y: 525,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 3
+                    new TestEnv.Item({
+                        value: windows[5],
+                        rect: {
+                            x: 750,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+
+        it("should do nothing if the focused column is already at the left", () => {
+            const { ok } = newModel.moveFocusedColumnLeft();
+
+            expect(ok).toBe(false);
+        });
+    });
+
+    describe("moveFocusedColumnRight should move the focused column to the right if possible", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+        const { model: newModel } = model.moveFocusedColumnRight();
+
+        it("should move the focused column to the right if possible", () => {
+            testGridItems(newModel.getGrid().items, [
+                [
+                    // Column 0
+                    new TestEnv.Item({
+                        value: windows[0],
+                        rect: {
+                            x: 250,
+                            y: 350,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[1],
+                        rect: {
+                            x: 300,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 1
+                    new TestEnv.Item({
+                        value: windows[3],
+                        rect: {
+                            x: 400,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[4],
+                        rect: {
+                            x: 350,
+                            y: 525,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 2 (Focused)
+                    new TestEnv.Item({
+                        value: windows[2],
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 3
+                    new TestEnv.Item({
+                        value: windows[5],
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+
+        it("should do nothing if the focused column is already at the right", () => {
+            const { model: newModel2 } = newModel.moveFocusedColumnRight();
+            const { ok } = newModel2.moveFocusedColumnRight();
+
+            expect(ok).toBe(false);
+        });
+    });
+
+    describe("moveFocusedItemUp should move the focused item up if possible", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should do nothing if the focused item is already at the top", () => {
+            const { ok } = model.moveFocusedItemUp();
+
+            expect(ok).toBe(false);
+        });
+
+        it("should move the focused item above if possible", () => {
+            const { model: newModel } = model.relayout(windows[1]);
+            const { model: newModel2 } = newModel.moveFocusedItemUp();
+
+            testGridItems(newModel2.getGrid().items, [
+                [
+                    // Column 0 (Focused)
+                    new TestEnv.Item({
+                        value: windows[1],
+                        rect: {
+                            x: 475,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[0],
+                        rect: {
+                            x: 450,
+                            y: 550,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 1
+                    new TestEnv.Item({
+                        value: windows[2],
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 2
+                    new TestEnv.Item({
+                        value: windows[3],
+                        rect: {
+                            x: 650,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[4],
+                        rect: {
+                            x: 650,
+                            y: 525,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 3
+                    new TestEnv.Item({
+                        value: windows[5],
+                        rect: {
+                            x: 750,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+    });
+
+    describe("moveFocusedItemDown", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should do nothing if the focused item is already at the bottom", () => {
+            const { ok } = model.moveFocusedItemDown();
+
+            expect(ok).toBe(false);
+        });
+
+        it("should move the focused item down if possible", () => {
+            const { model: newModel } = model.relayout(windows[3]);
+            const { model: newModel2 } = newModel.moveFocusedItemDown();
+
+            testGridItems(newModel2.getGrid().items, [
+                [
+                    // Column 0
+                    new TestEnv.Item({
+                        value: windows[0],
+                        rect: {
+                            x: 250,
+                            y: 350,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[1],
+                        rect: {
+                            x: 300,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 1
+                    new TestEnv.Item({
+                        value: windows[2],
+                        rect: {
+                            x: 350,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 2 (Focused)
+                    new TestEnv.Item({
+                        value: windows[4],
+                        rect: {
+                            x: 450,
+                            y: 375,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[3],
+                        rect: {
+                            x: 475,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                ],
+                [
+                    // Column 3
+                    new TestEnv.Item({
+                        value: windows[5],
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+    });
+
+    describe("insertWindow", () => {
+        const windows = createMockWindows();
+        const newWindow = createMockWindow(windows.length);
+
+        const model = createBaseModel(windows);
+
+        it("should insert a window into an empty model using different opening positions", () => {
+            const freshModel = new WorkspaceModel({
+                workspaceModelManager: createMockWorkspaceModelManager(windows),
+                workArea: { x: 0, y: 0, width: 1000, height: 1000 },
+            });
+            const { model: superFreshModel } =
+                freshModel.insertWindow(newWindow);
+
+            testGridItems(superFreshModel.getGrid().items, [
+                [
+                    new TestEnv.Item({
+                        value: newWindow,
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+
+            const newWindow2 = createMockWindow("newWindow2");
+            const { model: newModel2 } =
+                superFreshModel.insertWindow(newWindow2);
+
+            testGridItems(newModel2.getGrid().items, [
+                [
+                    new TestEnv.Item({
+                        value: newWindow2,
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    new TestEnv.Item({
+                        value: newWindow,
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+
+            const newWindow3 = createMockWindow("newWindow3");
+            const { model: newModel3 } = newModel2.insertWindow(newWindow3);
+
+            testGridItems(newModel3.getGrid().items, [
+                [
+                    new TestEnv.Item({
+                        value: newWindow2,
+                        rect: {
+                            x: 350,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    new TestEnv.Item({
+                        value: newWindow3,
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    new TestEnv.Item({
+                        value: newWindow,
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+
+            const newWindow4 = createMockWindow("newWindow4");
+            const { model: newModel4 } = newModel3
+                .clone({
+                    workspaceModelManager: createMockWorkspaceModelManager([
+                        newWindow4,
+                        newWindow3,
+                        newWindow2,
+                        newWindow,
+                    ]),
+                })
+                .insertWindow(newWindow4);
+
+            testGridItems(newModel4.getGrid().items, [
+                [
+                    new TestEnv.Item({
+                        value: newWindow2,
+                        rect: {
+                            x: 350,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    new TestEnv.Item({
+                        value: newWindow4,
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    new TestEnv.Item({
+                        value: newWindow3,
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    new TestEnv.Item({
+                        value: newWindow,
+                        rect: {
+                            x: 650,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+
+        it("should throw if the window is already in the model", () => {
+            expect(() => model.insertWindow(windows[0])).toThrow();
+        });
+
+        it("should insert a window into a filled model", () => {
+            const { model: newModel } = model.insertWindow(newWindow);
+
+            testGridItems(newModel.getGrid().items, [
+                [
+                    // Column 0
+                    new TestEnv.Item({
+                        value: windows[0],
+                        rect: {
+                            x: 350,
+                            y: 350,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[1],
+                        rect: {
+                            x: 400,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 1 (new and focused)
+                    new TestEnv.Item({
+                        value: newWindow,
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 2
+                    new TestEnv.Item({
+                        value: windows[2],
+                        rect: {
+                            x: 550,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 3
+                    new TestEnv.Item({
+                        value: windows[3],
+                        rect: {
+                            x: 650,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[4],
+                        rect: {
+                            x: 650,
+                            y: 525,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 4
+                    new TestEnv.Item({
+                        value: windows[5],
+                        rect: {
+                            x: 750,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+    });
+
+    describe("removeWindow", () => {
+        const windows = createMockWindows();
+        const model = createBaseModel(windows);
+
+        it("should throw if the window is not in the model", () => {
+            expect(() => model.removeWindow(createMockWindow(6))).toThrow();
+        });
+
+        it("should remove a window but not the column if it isn't the last window in it, then relayout", () => {
+            const { model: newModel } = model.removeWindow(
+                windows[0],
+                windows[2],
+            );
+
+            testGridItems(newModel.getGrid().items, [
+                [
+                    // Column 0
+                    new TestEnv.Item({
+                        value: windows[1],
+                        rect: {
+                            x: 400,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 1 (Focused)
+                    new TestEnv.Item({
+                        value: windows[2],
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 2
+                    new TestEnv.Item({
+                        value: windows[3],
+                        rect: {
+                            x: 550,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                    new TestEnv.Item({
+                        value: windows[4],
+                        rect: {
+                            x: 550,
+                            y: 525,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+                [
+                    // Column 3
+                    new TestEnv.Item({
+                        value: windows[5],
+                        rect: {
+                            x: 650,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+
+        it("should remove a window and its column if it's the last window in it, then relayout", () => {
+            const freshModel = new WorkspaceModel({
+                workspaceModelManager: createMockWorkspaceModelManager([]),
+                workArea: { x: 0, y: 0, width: 1000, height: 1000 },
+            });
+            const newWindow = createMockWindow(0);
+            const newWindow2 = createMockWindow(1);
+            const { model: oneWinModel } = freshModel.insertWindow(newWindow);
+            const { model: twoWinModel } = oneWinModel.insertWindow(newWindow2);
+            const { model: modelToTest } = twoWinModel.removeWindow(
+                newWindow,
+                newWindow2,
+            );
+
+            testGridItems(modelToTest.getGrid().items, [
+                [
+                    new TestEnv.Item({
+                        value: newWindow2,
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                ],
+            ]);
+        });
+
+        it("should remove the last column if the window is the last window in the model", () => {
+            const freshModel = new WorkspaceModel({
+                workspaceModelManager: createMockWorkspaceModelManager([]),
+                workArea: { x: 0, y: 0, width: 1000, height: 1000 },
+            });
+            const newWindow = createMockWindow(0);
+            const { model: superFreshModel } =
+                freshModel.insertWindow(newWindow);
+            const { model: shouldBeEmptyModel } =
+                superFreshModel.removeWindow(newWindow);
+
+            testGridItems(shouldBeEmptyModel.getGrid().items, []);
+        });
+    });
+});
 
 vi.mock("../../../src/shell/utils/debug.js", () => {
-    return { Debug: { assert: () => {} } };
+    return {
+        Debug: {
+            assert: (ok) => {
+                if (!ok) {
+                    throw new Error();
+                }
+            },
+            indentLog: () => {},
+            dedentLog: () => {},
+            log: () => {},
+            warn: () => {},
+            trace: () => {},
+            error: () => {},
+        },
+    };
 });
 
 vi.mock("../../../src/shell/utils/settings.js", () => {
     return {
         Settings: {
-            getWindowOpeningPosition: () => 0,
+            getWindowOpeningPosition: vi
+                .fn(() => TestEnv.WindowOpeningPosition.LEFT)
+                .mockImplementationOnce(
+                    () => TestEnv.WindowOpeningPosition.LEFT,
+                )
+                .mockImplementationOnce(
+                    () => TestEnv.WindowOpeningPosition.LEFT,
+                )
+                .mockImplementationOnce(
+                    () => TestEnv.WindowOpeningPosition.RIGHT,
+                )
+                .mockImplementationOnce(
+                    () => TestEnv.WindowOpeningPosition.BETWEEN_MRU,
+                ),
+            // TODO we need to test the different behaviors. But since I am
+            // unsure about the behavior of floating windows in columns, let's
+            // just wait for the implementation to be more stable.
             getFocusBehaviorMainAxis: () => 0,
             getFocusBehaviorCrossAxis: () => 0,
         },
     };
 });
 
+function testGridItems(items, expectedItems) {
+    expect(items.length).toBe(expectedItems.length);
+
+    for (let i = 0; i < items.length; i++) {
+        const col = items[i];
+        const expectedCol = expectedItems[i];
+
+        expect(col.length).toBe(expectedCol.length);
+
+        for (let j = 0; j < col.length; j++) {
+            const item = col[j];
+            const expectedItem = expectedCol[j];
+
+            expect(item.value).toBe(expectedItem.value);
+            expect(item.rect).toStrictEqual(expectedItem.rect);
+        }
+    }
+}
+
 function createMockWindow(id) {
     return {
         id,
-        focus: vi.fn(),
         get_frame_rect() {
             return {
                 x: 0,
@@ -42,11 +1017,18 @@ function createMockWindows() {
     ];
 }
 
+function createMockWorkspaceModelManager(windows) {
+    return {
+        getWindows: () => windows,
+    };
+}
+
 /**
  * @returns {WorkspaceModel}
  */
 function createBaseModel(windows) {
     return new WorkspaceModel({
+        workspaceModelManager: createMockWorkspaceModelManager(windows),
         focusedColumn: 1,
         workArea: {
             x: 0,
@@ -55,126 +1037,84 @@ function createBaseModel(windows) {
             height: 1000,
         },
         columns: [
-            {
-                // Column 0
+            // Column 0
+            new TestEnv.Column({
                 focusedItem: 1,
                 items: [
-                    {
+                    new TestEnv.Item({
                         value: windows[0],
-                        rect: { x: 350, y: 350, width: 100, height: 100 },
-                    },
-                    {
+                        rect: {
+                            x: 350,
+                            y: 350,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
+                    new TestEnv.Item({
                         value: windows[1],
-                        rect: { x: 400, y: 450, width: 50, height: 100 },
-                    },
+                        rect: {
+                            x: 400,
+                            y: 450,
+                            width: 50,
+                            height: 100,
+                        },
+                    }),
                 ],
-            },
-            {
-                // Column 1 (Focused)
+            }),
+            // Column 1 (Focused)
+            new TestEnv.Column({
                 focusedItem: 0,
                 items: [
-                    {
+                    new TestEnv.Item({
                         value: windows[2],
-                        rect: { x: 450, y: 450, width: 100, height: 100 },
-                    },
+                        rect: {
+                            x: 450,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
                 ],
-            },
-            {
-                // Column 2
+            }),
+            // Column 2
+            new TestEnv.Column({
                 focusedItem: 0,
                 items: [
-                    {
+                    new TestEnv.Item({
                         value: windows[3],
-                        rect: { x: 550, y: 475, width: 50, height: 50 },
-                    },
-                    {
+                        rect: {
+                            x: 550,
+                            y: 475,
+                            width: 50,
+                            height: 50,
+                        },
+                    }),
+                    new TestEnv.Item({
                         value: windows[4],
-                        rect: { x: 550, y: 525, width: 100, height: 100 },
-                    },
+                        rect: {
+                            x: 550,
+                            y: 525,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
                 ],
-            },
-            {
-                // Column 3
+            }),
+            // Column 3
+            new TestEnv.Column({
                 focusedItem: 0,
                 items: [
-                    {
+                    new TestEnv.Item({
                         value: windows[5],
-                        rect: { x: 650, y: 450, width: 100, height: 100 },
-                    },
+                        rect: {
+                            x: 650,
+                            y: 450,
+                            width: 100,
+                            height: 100,
+                        },
+                    }),
                 ],
-            },
+            }),
         ],
     });
 }
-
-describe("Workspace Model", () => {
-    it("getGrid should return the item grid in global coordinates", () => {
-        const windows = createMockWindows();
-        const model = createBaseModel(windows);
-        const grid = model.getGrid();
-
-        expect(grid.items).toStrictEqual([
-            [
-                // Column 0
-                {
-                    rect: {
-                        x: 350,
-                        y: 350,
-                        width: 100,
-                        height: 100,
-                    },
-                    value: windows[0],
-                },
-                {
-                    rect: {
-                        x: 400,
-                        y: 450,
-                        width: 50,
-                        height: 100,
-                    },
-                    value: windows[1],
-                },
-            ],
-            [
-                // Column 1 (Focused)
-                {
-                    rect: { x: 450, y: 450, width: 100, height: 100 },
-                    value: windows[2],
-                },
-            ],
-            [
-                // Column 2
-                {
-                    rect: {
-                        x: 550,
-                        y: 475,
-                        width: 50,
-                        height: 50,
-                    },
-                    value: windows[3],
-                },
-                {
-                    rect: {
-                        x: 550,
-                        y: 525,
-                        width: 100,
-                        height: 100,
-                    },
-                    value: windows[4],
-                },
-            ],
-            [
-                // Column 3
-                {
-                    rect: {
-                        x: 650,
-                        y: 450,
-                        width: 100,
-                        height: 100,
-                    },
-                    value: windows[5],
-                },
-            ],
-        ]);
-    });
-});


### PR DESCRIPTION
> This commit ports an older version of tests using deno to vitests.

---

(The deno test suite hasn't been part of a public branch though)

~~However, the  tests are currently broken as I've added more code to the data model since the tests have been written. Now that the data structures like Item and Column are more complex, I can't just work with objects that hold the same shape anymore since I'd need to manually fake a lot of methods... I should start using mocks now~~ **[Edit]** See commits